### PR TITLE
Remove canonical link from header for better indexing

### DIFF
--- a/themes/yeo/layout.tmpl
+++ b/themes/yeo/layout.tmpl
@@ -44,7 +44,7 @@
   	<link rel="icon" type="image/png" href="/images/icon.png">
   	<link rel="shortcut icon" href="/images/icon.png">
 
-    <link rel="canonical" href="https://betterdev.link">
+
     <link rel="image_src" href="/assets/images/thumbnail.png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.2/css/bulma.min.css">
     <link rel="stylesheet" href="/assets/css/main.css?{{ .Time }}">


### PR DESCRIPTION
Allows the articles to show up on https://app.daily.dev/sources/betterdevlink